### PR TITLE
rename route to params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function buildStubbedMfMaestroOptions(callbacksStore) {
 function getUrlParams() {
   const urlParams = new URLSearchParams(window.location.search);
   return {
-    routeParams: JSON5.parse(urlParams.get('route')) || {},
+    routeParams: JSON5.parse(urlParams.get('params')) || {},
     queryParams: JSON5.parse(urlParams.get('query')) || {}
   };
 }


### PR DESCRIPTION
params is easier to remember as MicroAppComponent takes `params={a: 1}` as attributes and not route